### PR TITLE
Place the initial cursor pointer outside the view to fix the issue of…

### DIFF
--- a/components/CursorPoint.vue
+++ b/components/CursorPoint.vue
@@ -26,8 +26,8 @@ addEventListener('mousemove', moveCursor)
   height: 0.5rem;
   width: 0.5rem;
   position: fixed;
-  top: 0;
-  left: 0;
+  top: -100px;
+  left: -100px;
   border-radius: 50%;
   z-index: -10;
   pointer-events: none;


### PR DESCRIPTION
… the glow cursor being displayed at 0,0 on mobile devices.